### PR TITLE
Feat workspaces from dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ local workspaces = require("workspaces")
 
 workspaces.add(path: string, name: string)
 
-workspaces.add_dir(path: string, no_logs: boolean)
+workspaces.add_dir(path: string)
 
 workspaces.remove(name: string)
 
-workspaces.removeDir(name: string, no_logs: boolean)
+workspaces.remove_dir(name: string)
 
 workspaces.rename(name: string, new_name: string)
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,19 @@ The setup function registers the following user commands:
 
   The workspace with the specified name and path will be registered.
 
+ * `:WorkspacesAddDir [path]`
+
+  The directory with the specified or current path will be registered
+  and each one of its sub folders stored as workspaces.
+
 * `:WorkspacesRemove [name]`
 
   The workspace with the specified name will be removed.
+
+* `:WorkspacesRemoveDir [name]`
+
+  The directory with the specified name will be removed
+  as well as all of its associated workspaces.
 
 * `:WorkspacesRename [name] [new_name]`
 
@@ -107,10 +117,18 @@ The setup function registers the following user commands:
 
   Prints all workspaces.
 
+* `:WorkspacesListDirs`
+
+  Prints all directories.
+
 * `:WorkspacesOpen [name]`
 
   Opens the named workspace. *opening* a workspace means to change the current
   directory to that workspace's path.
+
+* `:WorkspacesSyncDirs`
+
+  Synchronize workspaces from registered directories.
 
 See `:h workspaces-usage` for more information on the commands.
 
@@ -123,17 +141,26 @@ local workspaces = require("workspaces")
 
 workspaces.add(path: string, name: string)
 
+workspaces.add_dir(path: string, no_logs: boolean)
+
 workspaces.remove(name: string)
+
+workspaces.removeDir(name: string, no_logs: boolean)
 
 workspaces.rename(name: string, new_name: string)
 
 workspaces.list()
+
+workspaces.list_dirs()
 
 workspaces.open(name: string)
 
 workspaces.get(): table
 
 workspaces.name(): string|nil
+
+workspaces.sync_dirs()
+
 ```
 
 See `:h workspaces-api` for more information on the API functions.

--- a/doc/workspaces.txt
+++ b/doc/workspaces.txt
@@ -84,21 +84,51 @@ directory will be registered as a workspace, with the given name.
 if both name and path are provided, the workspace with name and path will be
 registered.
 
-:WorkspacesRemove [name]                             *WorkspacesRemove*
+:WorkspacesAddDir [path]                                *WorkspacesAddDir*
+
+If the path is omitted, the current working directory will be
+registered as a directory, with the last path segment as the name.
+
+Each subfolder of this directory will be automatically registered as a
+workspace.
+
+:WorkspacesRemove [name]                                *WorkspacesRemove*
 
 If name is omitted, the workspace registered in the current working
 directory will be removed, if it exists.
 
 If name is provided, the specified workspace will be removed.
 
-:WorkspacesList                                        *WorkspacesList*
+:WorkspacesRemoveDir [name]                             *WorkspacesRemoveDir*
+
+If name is omitted, the directory registered in the current working
+directory will be removed, if it exists.
+
+If name is provided, the specified directory will be removed.
+
+When a directory is removed, all of its subfolders registered as workspaces
+are also removed.
+
+:WorkspacesList                                         *WorkspacesList*
 
 Prints all workspaces.
 
-:WorkspacesOpen [name]                                 *WorkspacesOpen*
+:WorkspacesListDirs                                     *WorkspacesListDirs*
+
+Prints all directories.
+
+:WorkspacesOpen [name]                                  *WorkspacesOpen*
 
 Opens the named workspace. If no name is given, vim.ui.select() will be used
 as a selection interface for opening a workspace.
+
+:WorkspacesSyncDirs [name]                              *WorkspacesSyncDirs*
+
+For every registered directory, synchronizes workspaces based on the file
+system.
+
+If a directory subfolder has been removed or added, it will also be removed or
+added from the registered workspaces.
 
 All commands that take a workspace name (|:WorkspacesOpen| and
 |:WorkspacesRemove|) offer workspace name completion. |:WorkspacesAdd| offers

--- a/doc/workspaces.txt
+++ b/doc/workspaces.txt
@@ -175,20 +175,20 @@ workspaces.add(path: {string}, name: {string})
     Add a workspace with the given name and path. If name or path are nil, the
     current directory will be used to set the missing parameter.
 
-workspaces.addDir(path: {string}, no_logs: {boolean})
+workspaces.add_dir(path: {string})
     Add a directory with the given path. Register all its subfolders as
     workspaces.
 
 workspaces.remove(name: {string})
     Remove a workspace with the given name.
 
-workspaces.removeDir(path: {string}, no_logs: {boolean})
+workspaces.remove_dir(path: {string})
     Remove a directory and all its associated workspaces.
 
 workspaces.list()
     Print all workspaces to the commandline.
 
-workspaces.listDirs()
+workspaces.list_dirs()
     Print all directories to the commandline.
 
 workspaces.open(name: {string}|{nil})
@@ -203,7 +203,7 @@ workspaces.get(): {table}
 workspaces.name(): {string}|{nil}
     Returns the name of the current workspace or nil if no workspace is open.
     
-workspaces.syncDirs()
+workspaces.sync_dirs()
    Synchronize all workspaces that are subfolders of registered directories.
 
 ==============================================================================

--- a/doc/workspaces.txt
+++ b/doc/workspaces.txt
@@ -175,11 +175,21 @@ workspaces.add(path: {string}, name: {string})
     Add a workspace with the given name and path. If name or path are nil, the
     current directory will be used to set the missing parameter.
 
+workspaces.addDir(path: {string}, no_logs: {boolean})
+    Add a directory with the given path. Register all its subfolders as
+    workspaces.
+
 workspaces.remove(name: {string})
     Remove a workspace with the given name.
 
+workspaces.removeDir(path: {string}, no_logs: {boolean})
+    Remove a directory and all its associated workspaces.
+
 workspaces.list()
     Print all workspaces to the commandline.
+
+workspaces.listDirs()
+    Print all directories to the commandline.
 
 workspaces.open(name: {string}|{nil})
     Open a workspace with the given name. If name is nil, vim.ui.select() will be
@@ -192,6 +202,9 @@ workspaces.get(): {table}
 
 workspaces.name(): {string}|{nil}
     Returns the name of the current workspace or nil if no workspace is open.
+    
+workspaces.syncDirs()
+   Synchronize all workspaces that are subfolders of registered directories.
 
 ==============================================================================
 TELESCOPE                                               *workspaces-telescope*

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -2,42 +2,42 @@ local util = require("workspaces.util")
 local notify = util.notify
 
 local config = {
-    -- path to a file to store workspaces data in
-    -- on a unix system this would be ~/.local/share/nvim/workspaces
-    path = vim.fn.stdpath("data") .. util.path.sep .. "workspaces",
+	-- path to a file to store workspaces data in
+	-- on a unix system this would be ~/.local/share/nvim/workspaces
+	path = vim.fn.stdpath("data") .. util.path.sep .. "workspaces",
 
-    -- to change directory for nvim (:cd), or only for window (:lcd)
-    -- deprecated, use cd_type instead
-    global_cd = true,
+	-- to change directory for nvim (:cd), or only for window (:lcd)
+	-- deprecated, use cd_type instead
+	global_cd = true,
 
-    -- controls how the directory is changed. valid options are "global", "local", and "tab"
-    --   "global" changes directory for the neovim process. same as the :cd command
-    --   "local" changes directory for the current window. same as the :lcd command
-    --   "tab" changes directory for the current tab. same as the :tcd command
-    --
-    -- if set, overrides the value of global_cd, not set here to preserve backwards compatibility
-    -- cd_type = "global",
+	-- controls how the directory is changed. valid options are "global", "local", and "tab"
+	--   "global" changes directory for the neovim process. same as the :cd command
+	--   "local" changes directory for the current window. same as the :lcd command
+	--   "tab" changes directory for the current tab. same as the :tcd command
+	--
+	-- if set, overrides the value of global_cd, not set here to preserve backwards compatibility
+	-- cd_type = "global",
 
-    -- sort the list of workspaces after loading from the workspaces path
-    sort = true,
+	-- sort the list of workspaces after loading from the workspaces path
+	sort = true,
 
-    -- sort by recent use rather than by name. requires sort to be true
-    mru_sort = true,
+	-- sort by recent use rather than by name. requires sort to be true
+	mru_sort = true,
 
-    -- enable info-level notifications after adding or removing a workspace
-    notify_info = true,
+	-- enable info-level notifications after adding or removing a workspace
+	notify_info = true,
 
-    -- lists of hooks to run after specific actions
-    -- hooks can be a lua function or a vim command (string)
-    -- lua hooks take a name, a path, and an optional state table
-    -- if only one hook is needed, the list may be omitted
-    hooks = {
-        add = {},
-        remove = {},
-        rename = {},
-        open_pre = {},
-        open = {},
-    },
+	-- lists of hooks to run after specific actions
+	-- hooks can be a lua function or a vim command (string)
+	-- lua hooks take a name, a path, and an optional state table
+	-- if only one hook is needed, the list may be omitted
+	hooks = {
+		add = {},
+		remove = {},
+		rename = {},
+		open_pre = {},
+		open = {},
+	},
 }
 
 -- loads the workspaces from the datafile into a table
@@ -45,65 +45,67 @@ local config = {
 -- * newline separated workspace entries
 -- * NULL (\0) separated (name, path) pairs
 local load_workspaces = function()
-    local file = util.file.read(config.path)
+	local file = util.file.read(config.path)
 
-    -- if the file has not yet been created, add an empty file
-    if not file then
-        util.file.write(config.path, "")
-        file = util.file.read(config.path)
-    end
+	-- if the file has not yet been created, add an empty file
+	if not file then
+		util.file.write(config.path, "")
+		file = util.file.read(config.path)
+	end
 
-    local lines = vim.split(file, "\n", { trimempty = true })
+	local lines = vim.split(file, "\n", { trimempty = true })
 
-    local workspaces = {}
-    for _, line in ipairs(lines) do
-        local data = vim.split(line, "\0")
-        table.insert(workspaces, {
-            name = data[1],
-            path = vim.fn.fnamemodify(data[2], ":p"),
-            last_opened = data[3],
-        })
-    end
+	local workspaces = {}
+	for _, line in ipairs(lines) do
+		local data = vim.split(line, "\0")
+		table.insert(workspaces, {
+			name = data[1],
+			path = vim.fn.fnamemodify(data[2], ":p"),
+			last_opened = data[3],
+		})
+	end
 
-    if config.sort and #workspaces > 0 then
-        table.sort(workspaces, function(a, b)
-            if config.mru_sort then
-                if a.last_opened then
-                    if b.last_opened then return a.last_opened > b.last_opened end
-                    return true
-	        elseif b.last_opened then
-		    return false
-                else
-                    return a.name < b.name
-                end
-            else
-                return a.name < b.name
-            end
-        end)
-    end
+	if config.sort and #workspaces > 0 then
+		table.sort(workspaces, function(a, b)
+			if config.mru_sort then
+				if a.last_opened then
+					if b.last_opened then
+						return a.last_opened > b.last_opened
+					end
+					return true
+				elseif b.last_opened then
+					return false
+				else
+					return a.name < b.name
+				end
+			else
+				return a.name < b.name
+			end
+		end)
+	end
 
-    return workspaces
+	return workspaces
 end
 
 -- writes the workspaces from the table into the datafile
 local store_workspaces = function(workspaces)
-    local data = ""
-    for _, workspace in ipairs(workspaces) do
-        -- not all workspaces have a date
-        local date_str = workspace.last_opened and "\0" .. workspace.last_opened or ""
-        data = data .. string.format("%s\0%s%s\n", workspace.name, workspace.path, date_str)
-    end
-    util.file.write(config.path, data)
+	local data = ""
+	for _, workspace in ipairs(workspaces) do
+		-- not all workspaces have a date
+		local date_str = workspace.last_opened and "\0" .. workspace.last_opened or ""
+		data = data .. string.format("%s\0%s%s\n", workspace.name, workspace.path, date_str)
+	end
+	util.file.write(config.path, data)
 end
 
 local cwd = function()
-    return vim.fn.fnamemodify(vim.fn.getcwd(), ":p")
+	return vim.fn.fnamemodify(vim.fn.getcwd(), ":p")
 end
 
 local direq = function(a, b)
-    a = vim.fn.fnamemodify(a, ":p")
-    b = vim.fn.fnamemodify(b, ":p")
-    return a == b
+	a = vim.fn.fnamemodify(a, ":p")
+	b = vim.fn.fnamemodify(b, ":p")
+	return a == b
 end
 
 ---@param hook function|string
@@ -111,15 +113,17 @@ end
 ---@param path string
 ---@param state table|nil
 local run_hook = function(hook, name, path, state)
-    if type(hook) == "function" then
-        if hook(name, path, state) == false then return false end
-    elseif type(hook) == "string" then
-        vim.cmd(hook)
-    else
-        notify.err(string.format("Invalid workspace hook '%s'", hook))
-    end
+	if type(hook) == "function" then
+		if hook(name, path, state) == false then
+			return false
+		end
+	elseif type(hook) == "string" then
+		vim.cmd(hook)
+	else
+		notify.err(string.format("Invalid workspace hook '%s'", hook))
+	end
 
-    return true
+	return true
 end
 
 ---given a list of hooks, execute each in the order given
@@ -128,17 +132,23 @@ end
 ---@param path string
 ---@param state table|nil
 local run_hooks = function(hooks, name, path, state)
-    if not hooks then return end
+	if not hooks then
+		return
+	end
 
-    if type(hooks) == "table" then
-        for _, hook in ipairs(hooks) do
-            if run_hook(hook, name, path, state) == false then return false end
-        end
-    else
-        if run_hook(hooks, name, path, state) == false then return false end
-    end
+	if type(hooks) == "table" then
+		for _, hook in ipairs(hooks) do
+			if run_hook(hook, name, path, state) == false then
+				return false
+			end
+		end
+	else
+		if run_hook(hooks, name, path, state) == false then
+			return false
+		end
+	end
 
-    return true
+	return true
 end
 
 local M = {}
@@ -151,52 +161,52 @@ local M = {}
 ---@param path string|nil
 ---@param name string|nil
 M.add = function(path, name)
-    if not path and not name then
-        -- none given, use current directory and name
-        path = cwd()
-        name = util.path.basename(path)
-    elseif not name then
-        if string.find(path, util.path.sep) then
-            -- only path given, extract name from path
-            path = vim.fn.fnamemodify(path, ":p")
-            name = util.path.basename(path)
-        else
-            -- name given, use cwd as path
-            name = path
-            path = cwd()
-        end
-    else
-        -- both given, ensure the path is expanded
-        name, path = path, name
-        path = vim.fn.fnamemodify(path, ":p")
-    end
+	if not path and not name then
+		-- none given, use current directory and name
+		path = cwd()
+		name = util.path.basename(path)
+	elseif not name then
+		if string.find(path, util.path.sep) then
+			-- only path given, extract name from path
+			path = vim.fn.fnamemodify(path, ":p")
+			name = util.path.basename(path)
+		else
+			-- name given, use cwd as path
+			name = path
+			path = cwd()
+		end
+	else
+		-- both given, ensure the path is expanded
+		name, path = path, name
+		path = vim.fn.fnamemodify(path, ":p")
+	end
 
-    -- ensure path is valid
-    if vim.fn.isdirectory(path) == 0 then
-        notify.err(string.format("Path '%s' does not exist", path))
-        return
-    end
+	-- ensure path is valid
+	if vim.fn.isdirectory(path) == 0 then
+		notify.err(string.format("Path '%s' does not exist", path))
+		return
+	end
 
-    -- check if it already exists
-    local workspaces = load_workspaces()
-    for _, workspace in ipairs(workspaces) do
-        if workspace.name == name or workspace.path == path then
-            notify.warn(string.format("Workspace '%s' is already registered", workspace.name))
-            return
-        end
-    end
+	-- check if it already exists
+	local workspaces = load_workspaces()
+	for _, workspace in ipairs(workspaces) do
+		if workspace.name == name or workspace.path == path then
+			notify.warn(string.format("Workspace '%s' is already registered", workspace.name))
+			return
+		end
+	end
 
-    table.insert(workspaces, {
-        name = name,
-        path = path,
-    })
+	table.insert(workspaces, {
+		name = name,
+		path = path,
+	})
 
-    store_workspaces(workspaces)
-    run_hooks(config.hooks.add, name, path)
+	store_workspaces(workspaces)
+	run_hooks(config.hooks.add, name, path)
 
-    if config.notify_info then
-        notify.info(string.format("workspace [%s -> %s] added", name, path))
-    end
+	if config.notify_info then
+		notify.info(string.format("workspace [%s -> %s] added", name, path))
+	end
 end
 
 -- This function is a legacy of the older api, but it's not worth
@@ -205,51 +215,53 @@ end
 ---@param name string|nil
 ---@param path string|nil
 M.add_swap = function(name, path)
-    if name and path then
-        M.add(name, path)
-    elseif name and not path then
-        M.add(name, path)
-    else
-        M.add(path, name)
-    end
+	if name and path then
+		M.add(name, path)
+	elseif name and not path then
+		M.add(name, path)
+	else
+		M.add(path, name)
+	end
 end
 
 local find = function(name, path)
-    if not name then
-        name = util.path.basename(path)
-    end
+	if not name then
+		name = util.path.basename(path)
+	end
 
-    local workspaces = load_workspaces()
-    for i, workspace in ipairs(workspaces) do
-        if workspace.name == name or (path and direq(workspace.path, path)) then
-            return workspace, i
-        end
-    end
+	local workspaces = load_workspaces()
+	for i, workspace in ipairs(workspaces) do
+		if workspace.name == name or (path and direq(workspace.path, path)) then
+			return workspace, i
+		end
+	end
 
-    return nil
+	return nil
 end
 
 ---remove a workspace from the workspaces list by name
 ---name is optional, if omitted the current directory will be used
 ---@param name string|nil
 M.remove = function(name)
-    local path = cwd()
-    local workspace, i = find(name, path)
-    if not workspace then
-        if not name then return end
-        notify.warn(string.format("Workspace '%s' does not exist", name))
-        return
-    end
+	local path = cwd()
+	local workspace, i = find(name, path)
+	if not workspace then
+		if not name then
+			return
+		end
+		notify.warn(string.format("Workspace '%s' does not exist", name))
+		return
+	end
 
-    local workspaces = load_workspaces()
-    table.remove(workspaces, i)
-    store_workspaces(workspaces)
+	local workspaces = load_workspaces()
+	table.remove(workspaces, i)
+	store_workspaces(workspaces)
 
-    run_hooks(config.hooks.remove, workspace.name, workspace.path)
+	run_hooks(config.hooks.remove, workspace.name, workspace.path)
 
-    if config.notify_info then
-        notify.info(string.format("workspace [%s -> %s] removed", workspace.name, workspace.path))
-    end
+	if config.notify_info then
+		notify.info(string.format("workspace [%s -> %s] removed", workspace.name, workspace.path))
+	end
 end
 
 local current_workspace = nil
@@ -258,181 +270,191 @@ local current_workspace = nil
 ---@param name string
 ---@param new_name string
 M.rename = function(name, new_name)
-    local workspace, i = find(name)
-    if not workspace or not i then
-        if not name then return end
-        notify.warn(string.format("Workspace '%s' does not exist", name))
-        return
-    end
+	local workspace, i = find(name)
+	if not workspace or not i then
+		if not name then
+			return
+		end
+		notify.warn(string.format("Workspace '%s' does not exist", name))
+		return
+	end
 
-    workspace.name = new_name
-    local workspaces = load_workspaces()
-    workspaces[i] = workspace
-    store_workspaces(workspaces)
+	workspace.name = new_name
+	local workspaces = load_workspaces()
+	workspaces[i] = workspace
+	store_workspaces(workspaces)
 
-    if current_workspace == name then
-        current_workspace = workspace.name
-    end
+	if current_workspace == name then
+		current_workspace = workspace.name
+	end
 
-    run_hooks(config.hooks.rename, workspace.name, workspace.path, { previous_name = name })
+	run_hooks(config.hooks.rename, workspace.name, workspace.path, { previous_name = name })
 
-    if config.notify_info then
-        notify.info(string.format("workspace [%s -> %s] renamed", workspace.name, workspace.path))
-    end
+	if config.notify_info then
+		notify.info(string.format("workspace [%s -> %s] renamed", workspace.name, workspace.path))
+	end
 end
 
 ---returns the list of all workspaces
 ---each workspace is formatted as a { name = "", path = "" } table
 ---@return table
 M.get = function()
-    return load_workspaces()
+	return load_workspaces()
 end
 
 -- displays the list of workspaces
 M.list = function()
-    local workspaces = load_workspaces()
-    local ending = "\n"
+	local workspaces = load_workspaces()
+	local ending = "\n"
 
-    if #workspaces == 0 then
-        notify.warn("No workspaces are registered yet. Add one with :WorkspacesAdd")
-        return
-    end
+	if #workspaces == 0 then
+		notify.warn("No workspaces are registered yet. Add one with :WorkspacesAdd")
+		return
+	end
 
-    for i, workspace in ipairs(workspaces) do
-        if #workspaces == i then ending = "" end
-        print(string.format("%s %s%s", workspace.name, workspace.path, ending))
-    end
+	for i, workspace in ipairs(workspaces) do
+		if #workspaces == i then
+			ending = ""
+		end
+		print(string.format("%s %s%s", workspace.name, workspace.path, ending))
+	end
 end
 
 local select_fn = function(item, index)
-    -- prevent an infinite open loop
-    if not item then return end
-    M.open(item.name)
+	-- prevent an infinite open loop
+	if not item then
+		return
+	end
+	M.open(item.name)
 end
 
 local get_cd_command = function()
-    if config.cd_type then
-        if config.cd_type == "global" then
-            return "cd"
-        elseif config.cd_type == "local" then
-            return "lcd"
-        elseif config.cd_type == "tab" then
-            return "tcd"
-        end
-    elseif config.global_cd or config.global_cd == nil then
-        return "cd"
-    else
-        return "lcd"
-    end
+	if config.cd_type then
+		if config.cd_type == "global" then
+			return "cd"
+		elseif config.cd_type == "local" then
+			return "lcd"
+		elseif config.cd_type == "tab" then
+			return "tcd"
+		end
+	elseif config.global_cd or config.global_cd == nil then
+		return "cd"
+	else
+		return "lcd"
+	end
 end
 
 ---opens the named workspace
 ---this changes the current directory to the path specified in the workspace entry
 ---@param name string|nil
 M.open = function(name)
-    if not name then
-        local workspaces = load_workspaces()
-        vim.ui.select(workspaces, {
-            prompt = "Select workspace to open:",
-            format_item = function(item) return item.name end,
-        }, select_fn)
-        return
-    end
+	if not name then
+		local workspaces = load_workspaces()
+		vim.ui.select(workspaces, {
+			prompt = "Select workspace to open:",
+			format_item = function(item)
+				return item.name
+			end,
+		}, select_fn)
+		return
+	end
 
-    local workspace, index = find(name)
-    if not workspace then
-        notify.warn(string.format("Workspace '%s' does not exist", name))
-        return
-    end
+	local workspace, index = find(name)
+	if not workspace then
+		notify.warn(string.format("Workspace '%s' does not exist", name))
+		return
+	end
 
-    if run_hooks(config.hooks.open_pre, workspace.name, workspace.path) == false then
-        -- if any hooks aborted, then do not change directory
-        return
-    end
+	if run_hooks(config.hooks.open_pre, workspace.name, workspace.path) == false then
+		-- if any hooks aborted, then do not change directory
+		return
+	end
 
-    -- register this workspace as having been opened recently
-    local workspaces = load_workspaces()
-    workspaces[index].last_opened = util.date()
-    store_workspaces(workspaces)
+	-- register this workspace as having been opened recently
+	local workspaces = load_workspaces()
+	workspaces[index].last_opened = util.date()
+	store_workspaces(workspaces)
 
-    -- change directory
-    local cd_command = get_cd_command()
-    vim.cmd(string.format("%s %s", cd_command, workspace.path))
+	-- change directory
+	local cd_command = get_cd_command()
+	vim.cmd(string.format("%s %s", cd_command, workspace.path))
 
-    current_workspace = workspace.name
-    run_hooks(config.hooks.open, workspace.name, workspace.path)
+	current_workspace = workspace.name
+	run_hooks(config.hooks.open, workspace.name, workspace.path)
 end
 
 ---returns the name of the current workspace
 ---@return string|nil
 M.name = function()
-    return current_workspace
+	return current_workspace
 end
 
 local workspace_name_complete = function(lead)
-    local workspaces = vim.tbl_filter(function(workspace)
-        if lead == "" then return true end
-        return vim.startswith(workspace.name, lead)
-    end, load_workspaces())
+	local workspaces = vim.tbl_filter(function(workspace)
+		if lead == "" then
+			return true
+		end
+		return vim.startswith(workspace.name, lead)
+	end, load_workspaces())
 
-    return vim.tbl_map(function(workspace)
-        return workspace.name
-    end, workspaces)
+	return vim.tbl_map(function(workspace)
+		return workspace.name
+	end, workspaces)
 end
 
 -- completion for workspace names only
 M.workspace_complete = function(lead, _, _)
-    return workspace_name_complete(lead)
+	return workspace_name_complete(lead)
 end
 
 -- run to setup user commands and custom config
 M.setup = function(opts)
-    opts = opts or {}
-    config = vim.tbl_deep_extend("force", {}, config, opts)
+	opts = opts or {}
+	config = vim.tbl_deep_extend("force", {}, config, opts)
 
-    vim.api.nvim_create_user_command("WorkspacesAdd", function(cmd_opts)
-        require("workspaces").add_swap(unpack(cmd_opts.fargs))
-    end, {
-        desc = "Add a workspace via name and path.",
-        nargs = "*",
-        complete = "file",
-    })
+	vim.api.nvim_create_user_command("WorkspacesAdd", function(cmd_opts)
+		require("workspaces").add_swap(unpack(cmd_opts.fargs))
+	end, {
+		desc = "Add a workspace via name and path.",
+		nargs = "*",
+		complete = "file",
+	})
 
-    vim.api.nvim_create_user_command("WorkspacesRemove", function(cmd_opts)
-        require("workspaces").remove(unpack(cmd_opts.fargs))
-    end, {
-        desc = "Remove a workspace by name.",
-        nargs = "?",
-        complete = function(lead)
-            return require("workspaces").workspace_complete(lead)
-        end,
-    })
+	vim.api.nvim_create_user_command("WorkspacesRemove", function(cmd_opts)
+		require("workspaces").remove(unpack(cmd_opts.fargs))
+	end, {
+		desc = "Remove a workspace by name.",
+		nargs = "?",
+		complete = function(lead)
+			return require("workspaces").workspace_complete(lead)
+		end,
+	})
 
-    vim.api.nvim_create_user_command("WorkspacesRename", function(cmd_opts)
-        require("workspaces").rename(unpack(cmd_opts.fargs))
-    end, {
-        desc = "Rename a workspace by name to new name.",
-        nargs = "*",
-        complete = function(lead)
-            return require("workspaces").workspace_complete(lead)
-        end,
-    })
+	vim.api.nvim_create_user_command("WorkspacesRename", function(cmd_opts)
+		require("workspaces").rename(unpack(cmd_opts.fargs))
+	end, {
+		desc = "Rename a workspace by name to new name.",
+		nargs = "*",
+		complete = function(lead)
+			return require("workspaces").workspace_complete(lead)
+		end,
+	})
 
-    vim.api.nvim_create_user_command("WorkspacesList", function()
-        require("workspaces").list()
-    end, {
-        desc = "Print all workspaces.",
-    })
+	vim.api.nvim_create_user_command("WorkspacesList", function()
+		require("workspaces").list()
+	end, {
+		desc = "Print all workspaces.",
+	})
 
-    vim.api.nvim_create_user_command("WorkspacesOpen", function(cmd_opts)
-        require("workspaces").open(unpack(cmd_opts.fargs))
-    end, {
-        desc = "Open a workspace by name.",
-        nargs = "?",
-        complete = function(lead)
-            return require("workspaces").workspace_complete(lead)
-        end,
-    })
+	vim.api.nvim_create_user_command("WorkspacesOpen", function(cmd_opts)
+		require("workspaces").open(unpack(cmd_opts.fargs))
+	end, {
+		desc = "Open a workspace by name.",
+		nargs = "?",
+		complete = function(lead)
+			return require("workspaces").workspace_complete(lead)
+		end,
+	})
 end
 
 return M

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -221,8 +221,8 @@ end
 ---@param path string|nil
 ---@param name string|nil
 ---@param is_dir boolean|nil
----@param no_logs boolean|nil
-local add_workspace_or_directory = function(path, name, is_dir, no_logs)
+---@param from_dir_update boolean|nil
+local add_workspace_or_directory = function(path, name, is_dir, from_dir_update)
     local type = is_dir and "directory" or ""
     local type_name = is_dir and "Directory" or "Workspace"
 
@@ -267,9 +267,11 @@ local add_workspace_or_directory = function(path, name, is_dir, no_logs)
     })
 
     store_workspaces(workspaces)
-    run_hooks(config.hooks.add, name, path)
+    if not is_dir and not from_dir_update then
+        run_hooks(config.hooks.add, name, path)
+    end
 
-    if config.notify_info and not no_logs then
+    if config.notify_info and not from_dir_update then
         notify.info(string.format("workspace [%s -> %s] added", name, path))
     end
 end
@@ -278,8 +280,8 @@ end
 ---name is optional, if omitted the current directory will be used
 ---@param name string|nil
 ---@param is_dir boolean|nil
----@param no_logs boolean|nil
-local remove_workspace_or_directory = function(name, is_dir, no_logs)
+---@param from_dir_update boolean|nil
+local remove_workspace_or_directory = function(name, is_dir, from_dir_update)
     local type_name = is_dir and "Directory" or "Workspace"
     local path = cwd()
     local workspace, i = find(name, path, is_dir)
@@ -295,9 +297,11 @@ local remove_workspace_or_directory = function(name, is_dir, no_logs)
     table.remove(workspaces, i)
     store_workspaces(workspaces)
 
-    run_hooks(config.hooks.remove, workspace.name, workspace.path)
+    if not is_dir and not from_dir_update then
+        run_hooks(config.hooks.remove, workspace.name, workspace.path)
+    end
 
-    if config.notify_info and not no_logs then
+    if config.notify_info and not from_dir_update then
         notify.info(string.format("%s [%s -> %s] removed", type_name, workspace.name, workspace.path))
     end
 end

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -537,27 +537,30 @@ M.name = function()
     return current_workspace
 end
 
-local workspace_name_complete = function(lead, is_dir)
-    local workspaces = vim.tbl_filter(function(workspace)
+local workspace_or_dir_name_complete = function(lead, is_dir)
+    local data = get_workspaces_and_dirs()
+    local list_by_type = is_dir and data.directories or data.workspaces
+
+    local items = vim.tbl_filter(function(item)
         if lead == "" then
             return true
         end
-        return vim.startswith(workspace.name, lead)
-    end, load_workspaces())
+        return vim.startswith(item.name, lead)
+    end, list_by_type)
 
-    return vim.tbl_map(function(workspace)
-        return workspace.name
-    end, workspaces)
+    return vim.tbl_map(function(item)
+        return item.name
+    end, items)
 end
 
 -- completion for workspace names only
 M.workspace_complete = function(lead, _, _)
-    return workspace_name_complete(lead)
+    return workspace_or_dir_name_complete(lead)
 end
 
 -- completion for directory names only
 M.directory_complete = function(lead, _, _)
-    return workspace_name_complete(lead, true)
+    return workspace_or_dir_name_complete(lead, true)
 end
 
 --- sync all directories workspaces
@@ -609,7 +612,7 @@ M.setup = function(opts)
         desc = "Remove a directory and its workspaces.",
         nargs = "*",
         complete = function(lead)
-            return require("workspaces").workspace_complete(lead)
+            return require("workspaces").directory_complete(lead)
         end,
     })
 

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -565,13 +565,13 @@ M.sync_dirs = function()
         local stored_workspaces = get_dir_workspaces(dir.name)
         local new_workspaces = util.dir.read(dir.path)
 
-        -- if a directory workspace is not registered we create it
+        -- if a directory workspace is not registered we add it
         for _, path in ipairs(new_workspaces or {}) do
             local new_path = util.path.normalize(path)
             add_workspace_or_directory(new_path, nil, false, true)
         end
 
-        -- if a registered workspace doesn't exists in the directory we delete it
+        -- if a registered workspace doesn't exist in the file system we remove it
         for _, old in ipairs(stored_workspaces) do
             local exists = false
             for _, path in ipairs(new_workspaces or {}) do

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -407,15 +407,27 @@ M.workspace_complete = function(lead, _, _)
 	return workspace_name_complete(lead)
 end
 
--- adds directories
-M.add_directories = function(path)
+--- adds a directory subfolders as workspaces
+--- @param path string|nil
+M.add_directory = function(path)
 	if not path then
 		path = cwd()
 	end
 
 	local directories = util.dir.read(path)
 
-	print(directories)
+	if not directories then
+		return
+	end
+
+	for _, workspace_path in pairs(directories) do
+		local existing_workspace = find(nil, workspace_path)
+
+		if not existing_workspace then
+			local workspace_name = util.path.basename(workspace_path)
+			M.add_swap(workspace_name, workspace_path)
+		end
+	end
 end
 
 -- run to setup user commands and custom config
@@ -468,7 +480,7 @@ M.setup = function(opts)
 	})
 
 	vim.api.nvim_create_user_command("WorkspacesAddDir", function(cmd_opts)
-		require("workspaces").add_directories(unpack(cmd_opts.fargs))
+		require("workspaces").add_directory(unpack(cmd_opts.fargs))
 	end, {
 		desc = "Add all workspaces contained in a directory.",
 		nargs = "*",

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -244,12 +244,11 @@ local find = function(name, path, is_dir)
     return nil
 end
 
----remove a workspace or directory from the data list by name
+---remove a workspace or directory from the data file by name
 ---name is optional, if omitted the current directory will be used
 ---@param name string|nil
 M.remove = function(name, is_dir)
     local type_name = is_dir and "Directory" or "Workspace"
-    print("type name: ", type_name)
     local path = cwd()
     local workspace, i = find(name, path, is_dir)
     if not workspace then
@@ -475,7 +474,7 @@ local get_workspaces_and_dirs = function()
     return { workspaces = workspaces, directories = directories }
 end
 
-local get_directory_workspaces = function(dir_name)
+local get_dir_workspaces = function(dir_name)
     local data = get_workspaces_and_dirs()
 
     local directory_workspaces = {}
@@ -495,7 +494,7 @@ local get_directory_workspaces = function(dir_name)
 end
 
 M.remove_dir = function(dir_name)
-    local workspaces = get_directory_workspaces(dir_name)
+    local workspaces = get_dir_workspaces(dir_name)
 
     for _, workspace in ipairs(workspaces) do
         M.remove(workspace.name)
@@ -505,16 +504,14 @@ M.remove_dir = function(dir_name)
 end
 
 --- sync all directories workspaces
---[[ M.sync_dirs = function() ]]
---[[     local data = get_workspaces_and_dirs() ]]
---[[]]
---[[     for _, dir in ipairs(data.directories) do ]]
---[[         for _, workspace in ipairs(data.workspaces) do ]]
---[[             local parent = util.path.parent(workspace.path) ]]
---[[             print("parent: ", parent) ]]
---[[         end ]]
---[[     end ]]
---[[ end ]]
+M.sync_dirs = function()
+    local data = get_workspaces_and_dirs()
+
+    for _, dir in ipairs(data.directories) do
+        M.remove_dir(dir.name)
+        M.add_directory(dir.path)
+    end
+end
 
 -- run to setup user commands and custom config
 M.setup = function(opts)

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -591,7 +591,7 @@ M.setup = function(opts)
     vim.api.nvim_create_user_command("WorkspacesAddDir", function(cmd_opts)
         require("workspaces").add_dir(unpack(cmd_opts.fargs))
     end, {
-        desc = "Add all workspaces contained in a directory.",
+        desc = "Add a directory and register each one of its subfolders as workspaces.",
         nargs = "*",
         complete = "file",
     })
@@ -609,7 +609,7 @@ M.setup = function(opts)
     vim.api.nvim_create_user_command("WorkspacesRemoveDir", function(cmd_opts)
         require("workspaces").remove_dir(unpack(cmd_opts.fargs))
     end, {
-        desc = "Remove a directory and its workspaces.",
+        desc = "Remove a directory and its associated workspaces.",
         nargs = "*",
         complete = function(lead)
             return require("workspaces").directory_complete(lead)
@@ -651,7 +651,7 @@ M.setup = function(opts)
     vim.api.nvim_create_user_command("WorkspacesSyncDirs", function(cmd_opts)
         require("workspaces").sync_dirs()
     end, {
-        desc = "Synchronize all directory workspaces.",
+        desc = "Synchronize workspaces from registered directories.",
     })
 end
 

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -459,6 +459,11 @@ M.add_directory = function(path)
 	store_workspaces(workspaces)
 end
 
+--- sync all directories workspaces
+M.sync_dirs = function()
+	-- TODO
+end
+
 -- run to setup user commands and custom config
 M.setup = function(opts)
 	opts = opts or {}
@@ -512,6 +517,16 @@ M.setup = function(opts)
 		require("workspaces").add_directory(unpack(cmd_opts.fargs))
 	end, {
 		desc = "Add all workspaces contained in a directory.",
+		nargs = "*",
+		complete = function(lead)
+			return require("workspaces").workspace_complete(lead)
+		end,
+	})
+
+	vim.api.nvim_create_user_command("WorkspacesSyncDirs", function(cmd_opts)
+		require("workspaces").sync_dirs(unpack(cmd_opts.fargs))
+	end, {
+		desc = "Synchronize all directories workspaces.",
 		nargs = "*",
 		complete = function(lead)
 			return require("workspaces").workspace_complete(lead)

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -407,6 +407,17 @@ M.workspace_complete = function(lead, _, _)
 	return workspace_name_complete(lead)
 end
 
+-- adds directories
+M.add_directories = function(path)
+	if not path then
+		path = cwd()
+	end
+
+	local directories = util.dir.read(path)
+
+	print(directories)
+end
+
 -- run to setup user commands and custom config
 M.setup = function(opts)
 	opts = opts or {}
@@ -451,6 +462,16 @@ M.setup = function(opts)
 	end, {
 		desc = "Open a workspace by name.",
 		nargs = "?",
+		complete = function(lead)
+			return require("workspaces").workspace_complete(lead)
+		end,
+	})
+
+	vim.api.nvim_create_user_command("WorkspacesAddDir", function(cmd_opts)
+		require("workspaces").add_directories(unpack(cmd_opts.fargs))
+	end, {
+		desc = "Add all workspaces contained in a directory.",
+		nargs = "*",
 		complete = function(lead)
 			return require("workspaces").workspace_complete(lead)
 		end,

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -502,6 +502,8 @@ local get_dir_workspaces = function(dir_name)
     return directory_workspaces
 end
 
+--- sync all directories workspaces
+--- @param dir_name string
 M.remove_dir = function(dir_name)
     local workspaces = get_dir_workspaces(dir_name)
 

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -2,42 +2,42 @@ local util = require("workspaces.util")
 local notify = util.notify
 
 local config = {
-	-- path to a file to store workspaces data in
-	-- on a unix system this would be ~/.local/share/nvim/workspaces
-	path = vim.fn.stdpath("data") .. util.path.sep .. "workspaces",
+    -- path to a file to store workspaces data in
+    -- on a unix system this would be ~/.local/share/nvim/workspaces
+    path = vim.fn.stdpath("data") .. util.path.sep .. "workspaces",
 
-	-- to change directory for nvim (:cd), or only for window (:lcd)
-	-- deprecated, use cd_type instead
-	global_cd = true,
+    -- to change directory for nvim (:cd), or only for window (:lcd)
+    -- deprecated, use cd_type instead
+    global_cd = true,
 
-	-- controls how the directory is changed. valid options are "global", "local", and "tab"
-	--   "global" changes directory for the neovim process. same as the :cd command
-	--   "local" changes directory for the current window. same as the :lcd command
-	--   "tab" changes directory for the current tab. same as the :tcd command
-	--
-	-- if set, overrides the value of global_cd, not set here to preserve backwards compatibility
-	-- cd_type = "global",
+    -- controls how the directory is changed. valid options are "global", "local", and "tab"
+    --   "global" changes directory for the neovim process. same as the :cd command
+    --   "local" changes directory for the current window. same as the :lcd command
+    --   "tab" changes directory for the current tab. same as the :tcd command
+    --
+    -- if set, overrides the value of global_cd, not set here to preserve backwards compatibility
+    -- cd_type = "global",
 
-	-- sort the list of workspaces after loading from the workspaces path
-	sort = true,
+    -- sort the list of workspaces after loading from the workspaces path
+    sort = true,
 
-	-- sort by recent use rather than by name. requires sort to be true
-	mru_sort = true,
+    -- sort by recent use rather than by name. requires sort to be true
+    mru_sort = true,
 
-	-- enable info-level notifications after adding or removing a workspace
-	notify_info = true,
+    -- enable info-level notifications after adding or removing a workspace
+    notify_info = true,
 
-	-- lists of hooks to run after specific actions
-	-- hooks can be a lua function or a vim command (string)
-	-- lua hooks take a name, a path, and an optional state table
-	-- if only one hook is needed, the list may be omitted
-	hooks = {
-		add = {},
-		remove = {},
-		rename = {},
-		open_pre = {},
-		open = {},
-	},
+    -- lists of hooks to run after specific actions
+    -- hooks can be a lua function or a vim command (string)
+    -- lua hooks take a name, a path, and an optional state table
+    -- if only one hook is needed, the list may be omitted
+    hooks = {
+        add = {},
+        remove = {},
+        rename = {},
+        open_pre = {},
+        open = {},
+    },
 }
 
 -- loads the workspaces from the datafile into a table
@@ -45,69 +45,69 @@ local config = {
 -- * newline separated workspace entries
 -- * NULL (\0) separated (name, path) pairs
 local load_workspaces = function()
-	local file = util.file.read(config.path)
+    local file = util.file.read(config.path)
 
-	-- if the file has not yet been created, add an empty file
-	if not file then
-		util.file.write(config.path, "")
-		file = util.file.read(config.path)
-	end
+    -- if the file has not yet been created, add an empty file
+    if not file then
+        util.file.write(config.path, "")
+        file = util.file.read(config.path)
+    end
 
-	local lines = vim.split(file, "\n", { trimempty = true })
+    local lines = vim.split(file, "\n", { trimempty = true })
 
-	local workspaces = {}
-	for _, line in ipairs(lines) do
-		local data = vim.split(line, "\0")
-		table.insert(workspaces, {
-			name = data[1],
-			path = vim.fn.fnamemodify(data[2], ":p"),
-			last_opened = data[3],
-			type = data[4],
-		})
-	end
+    local workspaces = {}
+    for _, line in ipairs(lines) do
+        local data = vim.split(line, "\0")
+        table.insert(workspaces, {
+            name = data[1],
+            path = vim.fn.fnamemodify(data[2], ":p"),
+            last_opened = data[3],
+            type = data[4],
+        })
+    end
 
-	if config.sort and #workspaces > 0 then
-		table.sort(workspaces, function(a, b)
-			if config.mru_sort then
-				if a.last_opened then
-					if b.last_opened then
-						return a.last_opened > b.last_opened
-					end
-					return true
-				elseif b.last_opened then
-					return false
-				else
-					return a.name < b.name
-				end
-			else
-				return a.name < b.name
-			end
-		end)
-	end
+    if config.sort and #workspaces > 0 then
+        table.sort(workspaces, function(a, b)
+            if config.mru_sort then
+                if a.last_opened then
+                    if b.last_opened then
+                        return a.last_opened > b.last_opened
+                    end
+                    return true
+                elseif b.last_opened then
+                    return false
+                else
+                    return a.name < b.name
+                end
+            else
+                return a.name < b.name
+            end
+        end)
+    end
 
-	return workspaces
+    return workspaces
 end
 
 -- writes the workspaces from the table into the datafile
 local store_workspaces = function(workspaces)
-	local data = ""
-	for _, workspace in ipairs(workspaces) do
-		-- not all workspaces have a date
-		local date_str = workspace.last_opened or ""
-		local type = workspace.type or ""
-		data = data .. string.format("%s\0%s\0%s\0%s\n", workspace.name, workspace.path, date_str, type)
-	end
-	util.file.write(config.path, data)
+    local data = ""
+    for _, workspace in ipairs(workspaces) do
+        -- not all workspaces have a date
+        local date_str = workspace.last_opened or ""
+        local type = workspace.type or ""
+        data = data .. string.format("%s\0%s\0%s\0%s\n", workspace.name, workspace.path, date_str, type)
+    end
+    util.file.write(config.path, data)
 end
 
 local cwd = function()
-	return vim.fn.fnamemodify(vim.fn.getcwd(), ":p")
+    return vim.fn.fnamemodify(vim.fn.getcwd(), ":p")
 end
 
 local direq = function(a, b)
-	a = vim.fn.fnamemodify(a, ":p")
-	b = vim.fn.fnamemodify(b, ":p")
-	return a == b
+    a = vim.fn.fnamemodify(a, ":p")
+    b = vim.fn.fnamemodify(b, ":p")
+    return a == b
 end
 
 ---@param hook function|string
@@ -115,17 +115,17 @@ end
 ---@param path string
 ---@param state table|nil
 local run_hook = function(hook, name, path, state)
-	if type(hook) == "function" then
-		if hook(name, path, state) == false then
-			return false
-		end
-	elseif type(hook) == "string" then
-		vim.cmd(hook)
-	else
-		notify.err(string.format("Invalid workspace hook '%s'", hook))
-	end
+    if type(hook) == "function" then
+        if hook(name, path, state) == false then
+            return false
+        end
+    elseif type(hook) == "string" then
+        vim.cmd(hook)
+    else
+        notify.err(string.format("Invalid workspace hook '%s'", hook))
+    end
 
-	return true
+    return true
 end
 
 ---given a list of hooks, execute each in the order given
@@ -134,23 +134,23 @@ end
 ---@param path string
 ---@param state table|nil
 local run_hooks = function(hooks, name, path, state)
-	if not hooks then
-		return
-	end
+    if not hooks then
+        return
+    end
 
-	if type(hooks) == "table" then
-		for _, hook in ipairs(hooks) do
-			if run_hook(hook, name, path, state) == false then
-				return false
-			end
-		end
-	else
-		if run_hook(hooks, name, path, state) == false then
-			return false
-		end
-	end
+    if type(hooks) == "table" then
+        for _, hook in ipairs(hooks) do
+            if run_hook(hook, name, path, state) == false then
+                return false
+            end
+        end
+    else
+        if run_hook(hooks, name, path, state) == false then
+            return false
+        end
+    end
 
-	return true
+    return true
 end
 
 local M = {}
@@ -163,54 +163,54 @@ local M = {}
 ---@param path string|nil
 ---@param name string|nil
 M.add = function(path, name, dir)
-	local type = dir or ""
+    local type = dir or ""
 
-	if not path and not name then
-		-- none given, use current directory and name
-		path = cwd()
-		name = util.path.basename(path)
-	elseif not name then
-		if string.find(path, util.path.sep) then
-			-- only path given, extract name from path
-			path = vim.fn.fnamemodify(path, ":p")
-			name = util.path.basename(path)
-		else
-			-- name given, use cwd as path
-			name = path
-			path = cwd()
-		end
-	else
-		-- both given, ensure the path is expanded
-		name, path = path, name
-		path = vim.fn.fnamemodify(path, ":p")
-	end
+    if not path and not name then
+        -- none given, use current directory and name
+        path = cwd()
+        name = util.path.basename(path)
+    elseif not name then
+        if string.find(path, util.path.sep) then
+            -- only path given, extract name from path
+            path = vim.fn.fnamemodify(path, ":p")
+            name = util.path.basename(path)
+        else
+            -- name given, use cwd as path
+            name = path
+            path = cwd()
+        end
+    else
+        -- both given, ensure the path is expanded
+        name, path = path, name
+        path = vim.fn.fnamemodify(path, ":p")
+    end
 
-	-- ensure path is valid
-	if vim.fn.isdirectory(path) == 0 then
-		notify.err(string.format("Path '%s' does not exist", path))
-		return
-	end
+    -- ensure path is valid
+    if vim.fn.isdirectory(path) == 0 then
+        notify.err(string.format("Path '%s' does not exist", path))
+        return
+    end
 
-	-- check if it already exists
-	local workspaces = load_workspaces()
-	for _, workspace in ipairs(workspaces) do
-		if (workspace.name == name or workspace.path == path) and workspace.type == type then
-			notify.warn(string.format("Workspace '%s' is already registered", workspace.name))
-			return
-		end
-	end
+    -- check if it already exists
+    local workspaces = load_workspaces()
+    for _, workspace in ipairs(workspaces) do
+        if (workspace.name == name or workspace.path == path) and workspace.type == type then
+            notify.warn(string.format("Workspace '%s' is already registered", workspace.name))
+            return
+        end
+    end
 
-	table.insert(workspaces, {
-		name = name,
-		path = path,
-	})
+    table.insert(workspaces, {
+        name = name,
+        path = path,
+    })
 
-	store_workspaces(workspaces)
-	run_hooks(config.hooks.add, name, path)
+    store_workspaces(workspaces)
+    run_hooks(config.hooks.add, name, path)
 
-	if config.notify_info then
-		notify.info(string.format("workspace [%s -> %s] added", name, path))
-	end
+    if config.notify_info then
+        notify.info(string.format("workspace [%s -> %s] added", name, path))
+    end
 end
 
 -- This function is a legacy of the older api, but it's not worth
@@ -219,54 +219,54 @@ end
 ---@param name string|nil
 ---@param path string|nil
 M.add_swap = function(name, path)
-	if name and path then
-		M.add(name, path)
-	elseif name and not path then
-		M.add(name, path)
-	else
-		M.add(path, name)
-	end
+    if name and path then
+        M.add(name, path)
+    elseif name and not path then
+        M.add(name, path)
+    else
+        M.add(path, name)
+    end
 end
 
 local find = function(name, path, is_dir)
-	local type = is_dir and "directory" or ""
-	if not name then
-		name = util.path.basename(path)
-	end
+    local type = is_dir and "directory" or ""
+    if not name then
+        name = util.path.basename(path)
+    end
 
-	local workspaces = load_workspaces()
-	for i, workspace in ipairs(workspaces) do
-		if (workspace.name == name or (path and direq(workspace.path, path))) and workspace.type == type then
-			return workspace, i
-		end
-	end
+    local workspaces = load_workspaces()
+    for i, workspace in ipairs(workspaces) do
+        if (workspace.name == name or (path and direq(workspace.path, path))) and workspace.type == type then
+            return workspace, i
+        end
+    end
 
-	return nil
+    return nil
 end
 
 ---remove a workspace from the workspaces list by name
 ---name is optional, if omitted the current directory will be used
 ---@param name string|nil
 M.remove = function(name)
-	local path = cwd()
-	local workspace, i = find(name, path)
-	if not workspace then
-		if not name then
-			return
-		end
-		notify.warn(string.format("Workspace '%s' does not exist", name))
-		return
-	end
+    local path = cwd()
+    local workspace, i = find(name, path)
+    if not workspace then
+        if not name then
+            return
+        end
+        notify.warn(string.format("Workspace '%s' does not exist", name))
+        return
+    end
 
-	local workspaces = load_workspaces()
-	table.remove(workspaces, i)
-	store_workspaces(workspaces)
+    local workspaces = load_workspaces()
+    table.remove(workspaces, i)
+    store_workspaces(workspaces)
 
-	run_hooks(config.hooks.remove, workspace.name, workspace.path)
+    run_hooks(config.hooks.remove, workspace.name, workspace.path)
 
-	if config.notify_info then
-		notify.info(string.format("workspace [%s -> %s] removed", workspace.name, workspace.path))
-	end
+    if config.notify_info then
+        notify.info(string.format("workspace [%s -> %s] removed", workspace.name, workspace.path))
+    end
 end
 
 local current_workspace = nil
@@ -275,263 +275,263 @@ local current_workspace = nil
 ---@param name string
 ---@param new_name string
 M.rename = function(name, new_name)
-	local workspace, i = find(name)
-	if not workspace or not i then
-		if not name then
-			return
-		end
-		notify.warn(string.format("Workspace '%s' does not exist", name))
-		return
-	end
+    local workspace, i = find(name)
+    if not workspace or not i then
+        if not name then
+            return
+        end
+        notify.warn(string.format("Workspace '%s' does not exist", name))
+        return
+    end
 
-	workspace.name = new_name
-	local workspaces = load_workspaces()
-	workspaces[i] = workspace
-	store_workspaces(workspaces)
+    workspace.name = new_name
+    local workspaces = load_workspaces()
+    workspaces[i] = workspace
+    store_workspaces(workspaces)
 
-	if current_workspace == name then
-		current_workspace = workspace.name
-	end
+    if current_workspace == name then
+        current_workspace = workspace.name
+    end
 
-	run_hooks(config.hooks.rename, workspace.name, workspace.path, { previous_name = name })
+    run_hooks(config.hooks.rename, workspace.name, workspace.path, { previous_name = name })
 
-	if config.notify_info then
-		notify.info(string.format("workspace [%s -> %s] renamed", workspace.name, workspace.path))
-	end
+    if config.notify_info then
+        notify.info(string.format("workspace [%s -> %s] renamed", workspace.name, workspace.path))
+    end
 end
 
 ---returns the list of all workspaces
 ---each workspace is formatted as a { name = "", path = "" } table
 ---@return table
 M.get = function()
-	local workspaces_and_dirs = load_workspaces()
-	local workspaces = {}
-	for _, workspace in ipairs(workspaces_and_dirs) do
-		if workspace.type ~= "directory" then
-			table.insert(workspaces, workspace)
-		end
-	end
+    local workspaces_and_dirs = load_workspaces()
+    local workspaces = {}
+    for _, workspace in ipairs(workspaces_and_dirs) do
+        if workspace.type ~= "directory" then
+            table.insert(workspaces, workspace)
+        end
+    end
 
-	return workspaces
+    return workspaces
 end
 
 -- displays the list of workspaces
 M.list = function()
-	local workspaces = load_workspaces()
-	local ending = "\n"
+    local workspaces = load_workspaces()
+    local ending = "\n"
 
-	if #workspaces == 0 then
-		notify.warn("No workspaces are registered yet. Add one with :WorkspacesAdd")
-		return
-	end
+    if #workspaces == 0 then
+        notify.warn("No workspaces are registered yet. Add one with :WorkspacesAdd")
+        return
+    end
 
-	for i, workspace in ipairs(workspaces) do
-		if #workspaces == i then
-			ending = ""
-		end
-		if workspace.type ~= "directory" then
-			print(string.format("%s %s%s", workspace.name, workspace.path, ending))
-		end
-	end
+    for i, workspace in ipairs(workspaces) do
+        if #workspaces == i then
+            ending = ""
+        end
+        if workspace.type ~= "directory" then
+            print(string.format("%s %s%s", workspace.name, workspace.path, ending))
+        end
+    end
 end
 
 local select_fn = function(item, index)
-	-- prevent an infinite open loop
-	if not item then
-		return
-	end
-	M.open(item.name)
+    -- prevent an infinite open loop
+    if not item then
+        return
+    end
+    M.open(item.name)
 end
 
 local get_cd_command = function()
-	if config.cd_type then
-		if config.cd_type == "global" then
-			return "cd"
-		elseif config.cd_type == "local" then
-			return "lcd"
-		elseif config.cd_type == "tab" then
-			return "tcd"
-		end
-	elseif config.global_cd or config.global_cd == nil then
-		return "cd"
-	else
-		return "lcd"
-	end
+    if config.cd_type then
+        if config.cd_type == "global" then
+            return "cd"
+        elseif config.cd_type == "local" then
+            return "lcd"
+        elseif config.cd_type == "tab" then
+            return "tcd"
+        end
+    elseif config.global_cd or config.global_cd == nil then
+        return "cd"
+    else
+        return "lcd"
+    end
 end
 
 ---opens the named workspace
 ---this changes the current directory to the path specified in the workspace entry
 ---@param name string|nil
 M.open = function(name)
-	if not name then
-		local workspaces = load_workspaces()
-		vim.ui.select(workspaces, {
-			prompt = "Select workspace to open:",
-			format_item = function(item)
-				return item.name
-			end,
-		}, select_fn)
-		return
-	end
+    if not name then
+        local workspaces = load_workspaces()
+        vim.ui.select(workspaces, {
+            prompt = "Select workspace to open:",
+            format_item = function(item)
+                return item.name
+            end,
+        }, select_fn)
+        return
+    end
 
-	local workspace, index = find(name)
-	if not workspace then
-		notify.warn(string.format("Workspace '%s' does not exist", name))
-		return
-	end
+    local workspace, index = find(name)
+    if not workspace then
+        notify.warn(string.format("Workspace '%s' does not exist", name))
+        return
+    end
 
-	if run_hooks(config.hooks.open_pre, workspace.name, workspace.path) == false then
-		-- if any hooks aborted, then do not change directory
-		return
-	end
+    if run_hooks(config.hooks.open_pre, workspace.name, workspace.path) == false then
+        -- if any hooks aborted, then do not change directory
+        return
+    end
 
-	-- register this workspace as having been opened recently
-	local workspaces = load_workspaces()
-	workspaces[index].last_opened = util.date()
-	store_workspaces(workspaces)
+    -- register this workspace as having been opened recently
+    local workspaces = load_workspaces()
+    workspaces[index].last_opened = util.date()
+    store_workspaces(workspaces)
 
-	-- change directory
-	local cd_command = get_cd_command()
-	vim.cmd(string.format("%s %s", cd_command, workspace.path))
+    -- change directory
+    local cd_command = get_cd_command()
+    vim.cmd(string.format("%s %s", cd_command, workspace.path))
 
-	current_workspace = workspace.name
-	run_hooks(config.hooks.open, workspace.name, workspace.path)
+    current_workspace = workspace.name
+    run_hooks(config.hooks.open, workspace.name, workspace.path)
 end
 
 ---returns the name of the current workspace
 ---@return string|nil
 M.name = function()
-	return current_workspace
+    return current_workspace
 end
 
 local workspace_name_complete = function(lead)
-	local workspaces = vim.tbl_filter(function(workspace)
-		if lead == "" then
-			return true
-		end
-		return vim.startswith(workspace.name, lead)
-	end, load_workspaces())
+    local workspaces = vim.tbl_filter(function(workspace)
+        if lead == "" then
+            return true
+        end
+        return vim.startswith(workspace.name, lead)
+    end, load_workspaces())
 
-	return vim.tbl_map(function(workspace)
-		return workspace.name
-	end, workspaces)
+    return vim.tbl_map(function(workspace)
+        return workspace.name
+    end, workspaces)
 end
 
 -- completion for workspace names only
 M.workspace_complete = function(lead, _, _)
-	return workspace_name_complete(lead)
+    return workspace_name_complete(lead)
 end
 
 --- adds a directory subfolders as workspaces
 --- @param path string|nil
 M.add_directory = function(path)
-	if not path then
-		path = cwd()
-	end
+    if not path then
+        path = cwd()
+    end
 
-	local directories = util.dir.read(path)
-	if not directories then
-		return
-	end
+    local directories = util.dir.read(path)
+    if not directories then
+        return
+    end
 
-	for _, workspace_path in ipairs(directories) do
-		local existing_workspace = find(nil, workspace_path)
+    for _, workspace_path in ipairs(directories) do
+        local existing_workspace = find(nil, workspace_path)
 
-		if not existing_workspace then
-			local workspace_name = util.path.basename(workspace_path)
-			M.add(workspace_name, workspace_path)
-		end
-	end
+        if not existing_workspace then
+            local workspace_name = util.path.basename(workspace_path)
+            M.add(workspace_name, workspace_path)
+        end
+    end
 
-	local existing_dir = find(nil, path, true)
-	if existing_dir then
-		return
-	end
+    local existing_dir = find(nil, path, true)
+    if existing_dir then
+        return
+    end
 
-	local workspaces = load_workspaces()
+    local workspaces = load_workspaces()
 
-	table.insert(workspaces, {
-		name = util.path.basename(path),
-		path = path,
-		type = "directory",
-	})
+    table.insert(workspaces, {
+        name = util.path.basename(path),
+        path = path,
+        type = "directory",
+    })
 
-	store_workspaces(workspaces)
+    store_workspaces(workspaces)
 end
 
 --- sync all directories workspaces
 M.sync_dirs = function()
-	-- TODO
+    -- TODO
 end
 
 -- run to setup user commands and custom config
 M.setup = function(opts)
-	opts = opts or {}
-	config = vim.tbl_deep_extend("force", {}, config, opts)
+    opts = opts or {}
+    config = vim.tbl_deep_extend("force", {}, config, opts)
 
-	vim.api.nvim_create_user_command("WorkspacesAdd", function(cmd_opts)
-		require("workspaces").add_swap(unpack(cmd_opts.fargs))
-	end, {
-		desc = "Add a workspace via name and path.",
-		nargs = "*",
-		complete = "file",
-	})
+    vim.api.nvim_create_user_command("WorkspacesAdd", function(cmd_opts)
+        require("workspaces").add_swap(unpack(cmd_opts.fargs))
+    end, {
+        desc = "Add a workspace via name and path.",
+        nargs = "*",
+        complete = "file",
+    })
 
-	vim.api.nvim_create_user_command("WorkspacesRemove", function(cmd_opts)
-		require("workspaces").remove(unpack(cmd_opts.fargs))
-	end, {
-		desc = "Remove a workspace by name.",
-		nargs = "?",
-		complete = function(lead)
-			return require("workspaces").workspace_complete(lead)
-		end,
-	})
+    vim.api.nvim_create_user_command("WorkspacesRemove", function(cmd_opts)
+        require("workspaces").remove(unpack(cmd_opts.fargs))
+    end, {
+        desc = "Remove a workspace by name.",
+        nargs = "?",
+        complete = function(lead)
+            return require("workspaces").workspace_complete(lead)
+        end,
+    })
 
-	vim.api.nvim_create_user_command("WorkspacesRename", function(cmd_opts)
-		require("workspaces").rename(unpack(cmd_opts.fargs))
-	end, {
-		desc = "Rename a workspace by name to new name.",
-		nargs = "*",
-		complete = function(lead)
-			return require("workspaces").workspace_complete(lead)
-		end,
-	})
+    vim.api.nvim_create_user_command("WorkspacesRename", function(cmd_opts)
+        require("workspaces").rename(unpack(cmd_opts.fargs))
+    end, {
+        desc = "Rename a workspace by name to new name.",
+        nargs = "*",
+        complete = function(lead)
+            return require("workspaces").workspace_complete(lead)
+        end,
+    })
 
-	vim.api.nvim_create_user_command("WorkspacesList", function()
-		require("workspaces").list()
-	end, {
-		desc = "Print all workspaces.",
-	})
+    vim.api.nvim_create_user_command("WorkspacesList", function()
+        require("workspaces").list()
+    end, {
+        desc = "Print all workspaces.",
+    })
 
-	vim.api.nvim_create_user_command("WorkspacesOpen", function(cmd_opts)
-		require("workspaces").open(unpack(cmd_opts.fargs))
-	end, {
-		desc = "Open a workspace by name.",
-		nargs = "?",
-		complete = function(lead)
-			return require("workspaces").workspace_complete(lead)
-		end,
-	})
+    vim.api.nvim_create_user_command("WorkspacesOpen", function(cmd_opts)
+        require("workspaces").open(unpack(cmd_opts.fargs))
+    end, {
+        desc = "Open a workspace by name.",
+        nargs = "?",
+        complete = function(lead)
+            return require("workspaces").workspace_complete(lead)
+        end,
+    })
 
-	vim.api.nvim_create_user_command("WorkspacesAddDir", function(cmd_opts)
-		require("workspaces").add_directory(unpack(cmd_opts.fargs))
-	end, {
-		desc = "Add all workspaces contained in a directory.",
-		nargs = "*",
-		complete = function(lead)
-			return require("workspaces").workspace_complete(lead)
-		end,
-	})
+    vim.api.nvim_create_user_command("WorkspacesAddDir", function(cmd_opts)
+        require("workspaces").add_directory(unpack(cmd_opts.fargs))
+    end, {
+        desc = "Add all workspaces contained in a directory.",
+        nargs = "*",
+        complete = function(lead)
+            return require("workspaces").workspace_complete(lead)
+        end,
+    })
 
-	vim.api.nvim_create_user_command("WorkspacesSyncDirs", function(cmd_opts)
-		require("workspaces").sync_dirs(unpack(cmd_opts.fargs))
-	end, {
-		desc = "Synchronize all directories workspaces.",
-		nargs = "*",
-		complete = function(lead)
-			return require("workspaces").workspace_complete(lead)
-		end,
-	})
+    vim.api.nvim_create_user_command("WorkspacesSyncDirs", function(cmd_opts)
+        require("workspaces").sync_dirs(unpack(cmd_opts.fargs))
+    end, {
+        desc = "Synchronize all directories workspaces.",
+        nargs = "*",
+        complete = function(lead)
+            return require("workspaces").workspace_complete(lead)
+        end,
+    })
 end
 
 return M

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -332,7 +332,7 @@ M.add = function(path, name)
     add_workspace_or_directory(path, name)
 end
 
---- adds a directory subfolders as workspaces
+---adds a directory subfolders as workspaces
 ---@param path string|nil
 ---@param no_logs boolean|nil
 M.add_dir = function(path, no_logs)
@@ -649,7 +649,7 @@ M.setup = function(opts)
     })
 
     vim.api.nvim_create_user_command("WorkspacesSyncDirs", function(cmd_opts)
-        require("workspaces").sync_dirs(unpack(cmd_opts.fargs))
+        require("workspaces").sync_dirs()
     end, {
         desc = "Synchronize all directory workspaces.",
     })

--- a/lua/workspaces/util.lua
+++ b/lua/workspaces/util.lua
@@ -63,6 +63,16 @@ M.path.parent = function(path_str)
     return path .. M.path.sep
 end
 
+M.path.normalize = function(path_str)
+    local normalized = vim.fs.normalize(path_str)
+
+    if string.sub(normalized, #normalized) ~= M.path.sep then
+        normalized = normalized .. M.path.sep
+    end
+
+    return normalized
+end
+
 -- read a file into a string (synchronous)
 M.file = {}
 M.file.read = function(path)
@@ -85,33 +95,26 @@ end
 
 M.dir = {}
 M.dir.read = function(path)
-    local normalized_path = vim.fs.normalize(path)
-    local handle = uv.fs_scandir(normalized_path)
+    local normalized = M.path.normalize(path)
+
+    local handle = uv.fs_scandir(normalized)
 
     if not handle then
-        return nil, "Directory not found"
+        return nil
     end
 
     local directories = {}
-    local empty = true
     while true do
         local name, type = uv.fs_scandir_next(handle)
         if name == nil then
             break
         end
         if type == "directory" then
-            if empty then
-                empty = false
-            end
-            table.insert(directories, normalized_path .. name)
+            table.insert(directories, normalized .. name)
         end
     end
 
-    if empty then
-        return nil, "There are no folders in this directory"
-    else
-        return directories
-    end
+    return directories
 end
 
 return M

--- a/lua/workspaces/util.lua
+++ b/lua/workspaces/util.lua
@@ -5,92 +5,92 @@ local uv = vim.loop
 
 -- get datetime
 M.date = function()
-	return os.date("%Y-%m-%dT%H:%M:%S")
+    return os.date("%Y-%m-%dT%H:%M:%S")
 end
 
 -- vim.notify wrappers
 M.notify = {}
 M.notify.info = function(message)
-	vim.notify(message, levels.INFO, { title = "workspaces.nvim" })
+    vim.notify(message, levels.INFO, { title = "workspaces.nvim" })
 end
 
 M.notify.warn = function(message)
-	vim.notify(message, levels.WARN, { title = "workspaces.nvim" })
+    vim.notify(message, levels.WARN, { title = "workspaces.nvim" })
 end
 
 M.notify.err = function(message)
-	vim.notify(message, levels.ERROR, { title = "workspaces.nvim" })
+    vim.notify(message, levels.ERROR, { title = "workspaces.nvim" })
 end
 
 -- system dependent path separator from plenary.nvim
 M.path = {}
 M.path.sep = (function()
-	if jit then
-		local os = string.lower(jit.os)
-		if os == "linux" or os == "osx" or os == "bsd" then
-			return "/"
-		else
-			return "\\"
-		end
-	else
-		return package.config:sub(1, 1)
-	end
+    if jit then
+        local os = string.lower(jit.os)
+        if os == "linux" or os == "osx" or os == "bsd" then
+            return "/"
+        else
+            return "\\"
+        end
+    else
+        return package.config:sub(1, 1)
+    end
 end)()
 
 M.path.basename = function(path_str)
-	-- remove ending /
-	if string.sub(path_str, #path_str, #path_str) == M.path.sep then
-		path_str = string.sub(path_str, 1, #path_str - 1)
-	end
-	local parts = vim.split(path_str, M.path.sep)
-	return parts[#parts]
+    -- remove ending /
+    if string.sub(path_str, #path_str, #path_str) == M.path.sep then
+        path_str = string.sub(path_str, 1, #path_str - 1)
+    end
+    local parts = vim.split(path_str, M.path.sep)
+    return parts[#parts]
 end
 
 -- read a file into a string (synchronous)
 M.file = {}
 M.file.read = function(path)
-	local fd = uv.fs_open(path, "r", 438)
-	if not fd then
-		return nil
-	end
+    local fd = uv.fs_open(path, "r", 438)
+    if not fd then
+        return nil
+    end
 
-	local stat = assert(uv.fs_fstat(fd))
-	local data = assert(uv.fs_read(fd, stat.size, 0))
-	assert(uv.fs_close(fd))
-	return data
+    local stat = assert(uv.fs_fstat(fd))
+    local data = assert(uv.fs_read(fd, stat.size, 0))
+    assert(uv.fs_close(fd))
+    return data
 end
 
 -- write a string to a file (synchronous)
 M.file.write = function(path, data)
-	local fd = assert(uv.fs_open(path, "w", 438))
-	assert(uv.fs_write(fd, data, 0))
+    local fd = assert(uv.fs_open(path, "w", 438))
+    assert(uv.fs_write(fd, data, 0))
 end
 
 M.dir = {}
 M.dir.read = function(path)
-	-- TODO make it work for windows
-	local last_char = string.sub(path, string.len(path))
-	local end_path_command = "/*/"
+    -- TODO make it work for windows
+    local last_char = string.sub(path, string.len(path))
+    local end_path_command = "/*/"
 
-	if last_char == "/" then
-		end_path_command = "*/"
-	end
+    if last_char == "/" then
+        end_path_command = "*/"
+    end
 
-	local pdir, err = io.popen("ls -d " .. path .. end_path_command)
-	if not pdir or err then
-		return nil
-	end
+    local pdir, err = io.popen("ls -d " .. path .. end_path_command)
+    if not pdir or err then
+        return nil
+    end
 
-	local directories = {}
-	for line in pdir:lines() do
-		if line then
-			table.insert(directories, line)
-		end
-	end
+    local directories = {}
+    for line in pdir:lines() do
+        if line then
+            table.insert(directories, line)
+        end
+    end
 
-	pdir.close(pdir)
+    pdir.close(pdir)
 
-	return directories
+    return directories
 end
 
 return M

--- a/lua/workspaces/util.lua
+++ b/lua/workspaces/util.lua
@@ -66,4 +66,23 @@ M.file.write = function(path, data)
 	assert(uv.fs_write(fd, data, 0))
 end
 
+M.dir = {}
+M.dir.read = function(path)
+	local pdir, err = io.popen("ls -D " .. path)
+	if not pdir or err then
+		return nil
+	end
+
+	local directories = {}
+	for line in pdir:lines() do
+		if line then
+			table.insert(directories, line)
+		end
+	end
+
+	pdir.close(pdir)
+
+	return directories
+end
+
 return M

--- a/lua/workspaces/util.lua
+++ b/lua/workspaces/util.lua
@@ -5,63 +5,65 @@ local uv = vim.loop
 
 -- get datetime
 M.date = function()
-    return os.date("%Y-%m-%dT%H:%M:%S")
+	return os.date("%Y-%m-%dT%H:%M:%S")
 end
 
 -- vim.notify wrappers
 M.notify = {}
 M.notify.info = function(message)
-    vim.notify(message, levels.INFO, { title = "workspaces.nvim" })
+	vim.notify(message, levels.INFO, { title = "workspaces.nvim" })
 end
 
 M.notify.warn = function(message)
-    vim.notify(message, levels.WARN, { title = "workspaces.nvim" })
+	vim.notify(message, levels.WARN, { title = "workspaces.nvim" })
 end
 
 M.notify.err = function(message)
-    vim.notify(message, levels.ERROR, { title = "workspaces.nvim" })
+	vim.notify(message, levels.ERROR, { title = "workspaces.nvim" })
 end
 
 -- system dependent path separator from plenary.nvim
 M.path = {}
 M.path.sep = (function()
-    if jit then
-        local os = string.lower(jit.os)
-        if os == "linux" or os == "osx" or os == "bsd" then
-            return "/"
-        else
-            return "\\"
-        end
-    else
-        return package.config:sub(1, 1)
-    end
+	if jit then
+		local os = string.lower(jit.os)
+		if os == "linux" or os == "osx" or os == "bsd" then
+			return "/"
+		else
+			return "\\"
+		end
+	else
+		return package.config:sub(1, 1)
+	end
 end)()
 
 M.path.basename = function(path_str)
-    -- remove ending /
-    if string.sub(path_str, #path_str, #path_str) == M.path.sep then
-        path_str = string.sub(path_str, 1, #path_str - 1)
-    end
-    local parts = vim.split(path_str, M.path.sep)
-    return parts[#parts]
+	-- remove ending /
+	if string.sub(path_str, #path_str, #path_str) == M.path.sep then
+		path_str = string.sub(path_str, 1, #path_str - 1)
+	end
+	local parts = vim.split(path_str, M.path.sep)
+	return parts[#parts]
 end
 
 -- read a file into a string (synchronous)
 M.file = {}
 M.file.read = function(path)
-    local fd = uv.fs_open(path, "r", 438)
-    if not fd then return nil end
+	local fd = uv.fs_open(path, "r", 438)
+	if not fd then
+		return nil
+	end
 
-    local stat = assert(uv.fs_fstat(fd))
-    local data = assert(uv.fs_read(fd, stat.size, 0))
-    assert(uv.fs_close(fd))
-    return data
+	local stat = assert(uv.fs_fstat(fd))
+	local data = assert(uv.fs_read(fd, stat.size, 0))
+	assert(uv.fs_close(fd))
+	return data
 end
 
 -- write a string to a file (synchronous)
 M.file.write = function(path, data)
-    local fd = assert(uv.fs_open(path, "w", 438))
-    assert(uv.fs_write(fd, data, 0))
+	local fd = assert(uv.fs_open(path, "w", 438))
+	assert(uv.fs_write(fd, data, 0))
 end
 
 return M

--- a/lua/workspaces/util.lua
+++ b/lua/workspaces/util.lua
@@ -103,7 +103,7 @@ M.dir.read = function(path)
             if empty then
                 empty = false
             end
-            table.insert(directories, normalized_path .. M.path.sep .. name)
+            table.insert(directories, normalized_path .. name)
         end
     end
 

--- a/lua/workspaces/util.lua
+++ b/lua/workspaces/util.lua
@@ -68,7 +68,15 @@ end
 
 M.dir = {}
 M.dir.read = function(path)
-	local pdir, err = io.popen("ls -D " .. path)
+	-- TODO make it work for windows
+	local last_char = string.sub(path, string.len(path))
+	local end_path_command = "/*/"
+
+	if last_char == "/" then
+		end_path_command = "*/"
+	end
+
+	local pdir, err = io.popen("ls -d " .. path .. end_path_command)
 	if not pdir or err then
 		return nil
 	end

--- a/lua/workspaces/util.lua
+++ b/lua/workspaces/util.lua
@@ -37,13 +37,30 @@ M.path.sep = (function()
     end
 end)()
 
-M.path.basename = function(path_str)
+local get_path_parts = function(path_str)
     -- remove ending /
     if string.sub(path_str, #path_str, #path_str) == M.path.sep then
         path_str = string.sub(path_str, 1, #path_str - 1)
     end
-    local parts = vim.split(path_str, M.path.sep)
+
+    return vim.split(path_str, M.path.sep)
+end
+
+M.path.basename = function(path_str)
+    local parts = get_path_parts(path_str)
     return parts[#parts]
+end
+
+M.path.parent = function(path_str)
+    local parts = get_path_parts(path_str)
+    local path = ""
+    for i, part in ipairs(parts) do
+        if part ~= "" and i ~= #parts then
+            path = path .. M.path.sep .. part
+        end
+    end
+
+    return path .. M.path.sep
 end
 
 -- read a file into a string (synchronous)

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,7 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"


### PR DESCRIPTION
Hello @natecraddock!

Here is my work to support directory subfolders as workspaces.
There are some lint changes because i'm using stylua, I added a file config that match how the code was initially formatted to avoid big lint diffs but there are still tiny changes.

The Sync directories is just a command letting people manage it how they wish though autocmd (or by just running the command when needed). We could run it when opening nvim if needed.

When adding a directory, it stores it as directory, and registers its subfolders as workspaces.
When removing a directory, it removes it as well as its subfolders from workspaces.
When syncing directories, it deletes directory workspaces and recreates them to update everything.

Directories are stored at the same place than workspaces, a type column has been added to differentiate them. They have no date so no conflicts with workspaces sorted by date (they would not appear in results anyway).

I did not created any hook for directories because I didn't see any value, but it could be easily added if some people want it.

I tested this feature during my daily work and it seems working good, at least how I expected.

[update]: I improved the sync method that was just removing and recreating everything to not touch workspaces that was already existing, this way they keep their date and can be sorted.