### PR TITLE
option to autoload workspaces

### DIFF
--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -24,6 +24,9 @@ local config = {
     -- sort by recent use rather than by name. requires sort to be true
     mru_sort = true,
 
+    -- option to automatically activate workspace when opening neovim in a workspace directory
+    auto_open = true,
+
     -- enable info-level notifications after adding or removing a workspace
     notify_info = true,
 
@@ -591,6 +594,25 @@ M.sync_dirs = function()
     notify.info(string.format("Directory workspaces have been synced"))
 end
 
+-- function that adds a neovim autocmd that activates 
+local enable_autoload = function(opts)
+    opts = opts or {}
+    if opts.auto_open then
+      -- create autocmd for every file at the start of neovim that checks the current working directory
+      -- and if the cwd  matches a workspace directory then activate the corresponding workspace
+        vim.api.nvim_create_autocmd({ "VimEnter" }, {
+            pattern = "*",
+            callback = function()
+                for _, workspace in pairs(get_workspaces_and_dirs().workspaces) do
+                    if workspace.path == cwd() then
+                        M.open(workspace.name)
+                end
+              end
+            end,
+        })
+    end
+end
+
 -- run to setup user commands and custom config
 M.setup = function(opts)
     opts = opts or {}
@@ -669,6 +691,8 @@ M.setup = function(opts)
     end, {
         desc = "Synchronize workspaces from registered directories.",
     })
+
+    enable_autoload(opts)
 end
 
 return M

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -595,22 +595,19 @@ M.sync_dirs = function()
 end
 
 -- function that adds a neovim autocmd that activates 
-local enable_autoload = function(opts)
-    opts = opts or {}
-    if opts.auto_open then
-      -- create autocmd for every file at the start of neovim that checks the current working directory
-      -- and if the cwd  matches a workspace directory then activate the corresponding workspace
-        vim.api.nvim_create_autocmd({ "VimEnter" }, {
-            pattern = "*",
-            callback = function()
-                for _, workspace in pairs(get_workspaces_and_dirs().workspaces) do
-                    if workspace.path == cwd() then
-                        M.open(workspace.name)
-                end
+local enable_autoload = function()
+    -- create autocmd for every file at the start of neovim that checks the current working directory
+    -- and if the cwd  matches a workspace directory then activate the corresponding workspace
+      vim.api.nvim_create_autocmd({ "VimEnter" }, {
+          pattern = "*",
+          callback = function()
+              for _, workspace in pairs(get_workspaces_and_dirs().workspaces) do
+                  if workspace.path == cwd() then
+                      M.open(workspace.name)
               end
-            end,
-        })
-    end
+            end
+          end,
+      })
 end
 
 -- run to setup user commands and custom config
@@ -692,7 +689,9 @@ M.setup = function(opts)
         desc = "Synchronize workspaces from registered directories.",
     })
 
-    enable_autoload(opts)
+    if opts.auto_open then
+        enable_autoload()
+    end
 end
 
 return M


### PR DESCRIPTION
I added an option to autoload workspaces when starting neovim in a directory that is registered as a workspace directory.
This could further be expanded by adding an autoload option to each workspace when it is being added.

This is my first time doing a pull request so please excuse me if I'm doing something wrong.
(My code formater formats the code differently so there may be some formatting errors)