### PR TITLE
feat(telescope): Add support to opening a workspace in a new tab

### DIFF
--- a/lua/telescope/_extensions/workspaces.lua
+++ b/lua/telescope/_extensions/workspaces.lua
@@ -70,6 +70,19 @@ local workspaces_picker = function(opts)
                     workspaces.open(workspace.name)
                 end
             end)
+
+            actions.select_tab:replace(function()
+                actions.close(prompt_bufnr)
+                local selected = action_state.get_selected_entry()
+                if not selected then return end
+
+                local workspace = selected.value
+                if workspace and workspace ~="" then
+                  vim.cmd('tabnew')
+                  workspaces.open(workspace.name)
+                end
+            end)
+
             return true
         end,
     }):find()


### PR DESCRIPTION
Hello folks!

Before anything, great plugin! Just found out about it while revamping my neovim setup and I think it's exactly what I'm missing to have some nice control on how to open different projects!

I added a small modification, just enabling me to actually open the workspace on a new tab from telescope. This actually enables me a really nice flow:
- Use Telescope to find the workspace I want
- Open it in a new tab
- Open NvimTree on the workspace directory
- Rename the  tab to the workspace name
