### PR TITLE
feat(api): Add workspaces.path()

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ workspaces.get(): table
 
 workspaces.name(): string|nil
 
+workspaces.path(): string|nil
+
 workspaces.sync_dirs()
 
 ```

--- a/doc/workspaces.txt
+++ b/doc/workspaces.txt
@@ -206,6 +206,9 @@ workspaces.get(): {table}
 workspaces.name(): {string}|{nil}
     Returns the name of the current workspace or nil if no workspace is open.
 
+workspaces.path(): {string}|{nil}
+    Returns the path of the current workspace or nil if no workspace is open.
+
 workspaces.sync_dirs()
    Synchronize all workspaces that are subfolders of registered directories.
 

--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -431,8 +431,8 @@ M.rename = function(name, new_name)
     workspaces[i] = workspace
     store_workspaces(workspaces)
 
-    if current_workspace == name then
-        current_workspace = workspace.name
+    if current_workspace and current_workspace.name == name then
+        current_workspace = workspace
     end
 
     run_hooks(config.hooks.rename, workspace.name, workspace.path, { previous_name = name })
@@ -524,14 +524,20 @@ M.open = function(name)
     local cd_command = get_cd_command()
     vim.cmd(string.format("%s %s", cd_command, workspace.path))
 
-    current_workspace = workspace.name
+    current_workspace = workspace
     run_hooks(config.hooks.open, workspace.name, workspace.path)
 end
 
 ---returns the name of the current workspace
 ---@return string|nil
 M.name = function()
-    return current_workspace
+    return current_workspace and current_workspace.name
+end
+
+---returns the path of the current workspace
+---@return string|nil
+M.path = function()
+    return current_workspace and current_workspace.path
 end
 
 local workspace_or_dir_name_complete = function(lead, is_dir)


### PR DESCRIPTION
Goes from:
```lua
function M.get_workspace_path()
	local workspaces = require 'workspaces'
	local saved_workspaces = workspaces.get()

	local current_workspace = workspaces.name()
	if current_workspace == nil then
		return
	end

	for _, workspace in ipairs(saved_workspaces) do
		if current_workspace == workspace.name then
			local path = workspace.path
			if path:sub(-1, -1) == '/' then
				path = path:sub(1, -2)
			end
			return path
		end
	end
end

```
to:
```lua
function M.get_workspace_path()
	local workspaces = require 'workspaces'

	local current_workspace_path = workspaces.path()
	if current_workspace_path == nil then
		return
	end

	return vim.fs.normalize(current_workspace_path)
end
```

I use this to force a `root_dir` for `nvim-lspconfig`, useful when go-to-definition brings you to a header file outside your project's root.