### PR TITLE
Add buffer delete to session switching example

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ Load any saved sessions using
 ```lua
 require("workspaces").setup({
     hooks = {
+        open_pre = {
+          -- If recording, save current session state and stop recording
+          "SessionsStop",
+
+          -- delete all buffers (does not save changes)
+          "silent %bdelete!",
+        },
         open = function()
           require("sessions").load(nil, { silent = true })
         end,


### PR DESCRIPTION
The existing example in README under the 'Load a saved session' example does not delete existing buffers when opening a new workspace, meaning they get added to the newly opened session.

The deletion code is from your Reddit comment here: https://www.reddit.com/r/neovim/comments/sg10tj/comment/huut0g8/