### PR TITLE
Ensure the startup autocmd is nested

### DIFF
--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -636,6 +636,7 @@ local enable_autoload = function()
     -- and if the cwd  matches a workspace directory then activate the corresponding workspace
       vim.api.nvim_create_autocmd({ "VimEnter" }, {
           pattern = "*",
+          nested = true,
           callback = function()
               for _, workspace in pairs(get_workspaces_and_dirs().workspaces) do
                   -- dont autoload if nvim start with arg


### PR DESCRIPTION
Because of some inner neovim details[1], this has to be nested in order to properly setup ft and other plugins.

Fixes #31

[1] https://github.com/neovim/neovim/issues/8136#issuecomment-373082539