### PR TITLE
fix: Set workspace before changing directory for "DirChanged" autocommands

### DIFF
--- a/lua/workspaces/init.lua
+++ b/lua/workspaces/init.lua
@@ -520,11 +520,12 @@ M.open = function(name)
     workspaces[index].last_opened = util.date()
     store_workspaces(workspaces)
 
+    current_workspace = workspace
+
     -- change directory
     local cd_command = get_cd_command()
     vim.cmd(string.format("%s %s", cd_command, workspace.path))
 
-    current_workspace = workspace
     run_hooks(config.hooks.open, workspace.name, workspace.path)
 end
 


### PR DESCRIPTION
Users aren't able to reference the current workspace in a "DirChanged" autocommand, since it is set after ":cd" is called.  This just swaps the order when opening a workspace.