### PR TITLE
feat: Adding "auto_dir" to enable a "DirChanged" autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ The setup function accepts a table to modify the default configuration:
     -- option to automatically activate workspace when opening neovim in a workspace directory
     auto_open = false,
 
+    -- option to automatically activate workspace when changing directory not via this plugin
+    auto_dir = false,
+
     -- enable info-level notifications after adding or removing a workspace
     notify_info = true,
 

--- a/doc/workspaces.txt
+++ b/doc/workspaces.txt
@@ -57,6 +57,9 @@ configuration. >
         -- option to automatically activate workspace when opening neovim in a workspace directory
         auto_open = false,
 
+        -- option to automatically activate workspace when changing directory not via this plugin
+        auto_dir = false,
+
         -- enable info-level notifications after adding or removing a
         -- workspace. disable to only be notified for warnings or errors.
         notify_info = true,


### PR DESCRIPTION
This adds an option to create a "DirChanged" autocmd that will activate (and "deactivate") the workspace if the directory is changed not via this plugin, for example, via a manual ":cd" or another plugin.

I thought the deactivate part is useful since I personally added the workspace name to my status bar, and the current workspace would remain if I used ":cd" to change to another directory.

I set the config default to off.

Let me know if you like this feature and if the naming is ok, I wasn't sure the best name for the config option.