### PR TITLE
feat: change hl group of path in telescope config

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ running any registered hooks. `<c-t>` will open the selected workspace in a new 
 
 To keep nvim in insert mode (for example, when
 chaining multiple telescope pickers), add the following to your telescope setup
-function.
+function. You can also specify the highlight group used for the path in
+the picker. 
 
 ```lua
 require("telescope").setup({

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ require("telescope").setup({
     workspaces = {
       -- keep insert mode after selection in the picker, default is false
       keep_insert = true,
+      -- Highlight group used for the path in the picker, default is "String"
+      path_hl = "String"
     }
   }
 })

--- a/doc/workspaces.txt
+++ b/doc/workspaces.txt
@@ -234,13 +234,17 @@ running any registered hooks. `<c-t>` will open the selected workspace in a new 
 
 To keep nvim in insert mode (for example, when
 chaining multiple telescope pickers), add the following to your telescope
-setup function. >
+setup function. You can also specify the highlight group used for the path in
+the picker. >
 
     require("telescope").setup({
       extensions = {
         workspaces = {
           -- keep insert mode after selection in the picker, default is false
           keep_insert = true,
+          -- highlight group used for the path in the picker, default is
+          "String"
+          path_hl = "String",
         }
       }
     })

--- a/lua/telescope/_extensions/workspaces.lua
+++ b/lua/telescope/_extensions/workspaces.lua
@@ -9,6 +9,7 @@ local telescope = require("telescope")
 local workspaces = require("workspaces")
 
 local keep_insert = false
+local path_hl = "String"
 
 local workspaces_picker = function(opts)
     -- compute spacing
@@ -40,7 +41,7 @@ local workspaces_picker = function(opts)
                     display = function(entry)
                         return displayer({
                             { entry.ordinal },
-                            { entry.value.path, "String" },
+                            { entry.value.path, path_hl },
                         })
                     end,
                     ordinal = entry.name,
@@ -92,6 +93,9 @@ return telescope.register_extension({
     setup = function(ext_config)
         if ext_config.keep_insert then
             keep_insert = ext_config.keep_insert
+        end
+        if ext_config.path_hl then
+            path_hl = ext_config.path_hl
         end
     end,
 


### PR DESCRIPTION
Add ability to change the highlight group of the path in the picker to something else.

Set to "Delimeter"
<img width="500" alt="image" src="https://github.com/user-attachments/assets/965e46f6-79f4-4262-84ef-cac61b0f7435">

Unset (string)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/703afc52-487f-4d72-a1bc-a9c38562c738">
